### PR TITLE
Update Android project for compatibility with Flutter 3.27

### DIFF
--- a/simple_file_saver/example/android/gradle.properties
+++ b/simple_file_saver/example/android/gradle.properties
@@ -1,3 +1,6 @@
 org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/simple_file_saver/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/simple_file_saver/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Dec 31 13:01:38 CET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-all.zip

--- a/simple_file_saver/example/android/settings.gradle
+++ b/simple_file_saver/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
+    id "com.android.application" version '8.1.4' apply false
     id "org.jetbrains.kotlin.android" version "1.9.10" apply false
 }
 


### PR DESCRIPTION
Flutter 3.27 uses compileSdk 35 on Android, which requires AGP 8.1.0 or higher:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:bundleReleaseResources'.
> A failure occurred while executing com.android.build.gradle.internal.res.Aapt2ProcessResourcesRunnable
   > Android resource linking failed
     aapt2 E 12-31 12:56:23 150001 150001 LoadedArsc.cpp:94] RES_TABLE_TYPE_TYPE entry offsets overlap actual entry data.
     aapt2 E 12-31 12:56:23 150001 150001 ApkAssets.cpp:149] Failed to load resources table in APK '/home/maurix/Android/Sdk/platforms/android-35/android.jar'.
     error: failed to load include path /home/maurix/Android/Sdk/platforms/android-35/android.jar.


* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 16s
Running Gradle task 'assembleRelease'...                           17.2s

┌─ Flutter Fix ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ [!] Using compileSdk 35 requires Android Gradle Plugin (AGP) 8.1.0 or higher.                                                         │
│  Please upgrade to a newer AGP version. The version of AGP that your project uses is likely defined in:                               │
│ /home/maurix/Projects/simple_file_saver/simple_file_saver/example/android/settings.gradle,                                            │
│ in the 'plugins' closure (by the number following "com.android.application").                                                         │
│  Alternatively, if your project was created with an older version of the templates, it is likely                                      │
│ in the buildscript.dependencies closure of the top-level build.gradle:                                                                │
│ /home/maurix/Projects/simple_file_saver/simple_file_saver/example/android/build.gradle,                                               │
│ as the number following "com.android.tools.build:gradle:".                                                                            │
│                                                                                                                                       │
│  Finally, if you have a strong reason to avoid upgrading AGP, you can temporarily lower the compileSdk version in the following file: │
│ /home/maurix/Projects/simple_file_saver/simple_file_saver/example/android/app/build.gradle                                            │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
Gradle task assembleRelease failed with exit code 1
```

This PR updates AGP to 8.1.4.
