### PR TITLE
Upgrade mime to 2.0.0

### DIFF
--- a/simple_file_saver_platform_interface/lib/src/utils/mime_converter.dart
+++ b/simple_file_saver_platform_interface/lib/src/utils/mime_converter.dart
@@ -2,14 +2,6 @@ import 'dart:typed_data';
 
 import 'package:mime/mime.dart' as mime;
 
-String? extensionFromMimeType(String? mimeType) {
-  if (mimeType != null) {
-    return mime.extensionFromMime(mimeType);
-  }
-
-  return null;
-}
-
 /// Attempt to use the extension in resolving the mime type first, and then try the header bytes if it fails
 String? mimeTypeLookup({required String path, Uint8List? dataBytes}) {
   return mime.lookupMimeType(

--- a/simple_file_saver_platform_interface/pubspec.yaml
+++ b/simple_file_saver_platform_interface/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   plugin_platform_interface: ^2.1.8
   url_launcher: ^6.2.6
-  mime: ^1.0.5
+  mime: ^2.0.0
   path: ^1.9.0
 
 dev_dependencies:


### PR DESCRIPTION
This PR updates mime dependency to 2.0.0 and removes the unused `extensionFromMimeType()` function.
This is a fix for #2 .